### PR TITLE
Switch to Picasso to reduce method count

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     compile 'com.jakewharton:butterknife:8.1.0'
     apt 'com.jakewharton:butterknife-compiler:8.1.0'
     compile 'com.squareup.retrofit2:retrofit:2.1.0'
-    compile 'com.github.bumptech.glide:glide:3.7.0'
+    compile 'com.squareup.picasso:picasso:2.5.2'
 
     compile 'com.trello:navi:0.2.0'
     compile 'io.reactivex:rxjava:1.1.6'

--- a/app/src/main/java/com/bnorm/barkeep/lib/BindingAdapters.java
+++ b/app/src/main/java/com/bnorm/barkeep/lib/BindingAdapters.java
@@ -5,9 +5,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import android.databinding.BindingAdapter;
 import android.widget.ImageView;
 import com.bnorm.barkeep.R;
-import com.bumptech.glide.DrawableTypeRequest;
-import com.bumptech.glide.Glide;
-import com.bumptech.glide.RequestManager;
+import com.squareup.picasso.Picasso;
+import com.squareup.picasso.RequestCreator;
 
 public class BindingAdapters {
 
@@ -21,17 +20,13 @@ public class BindingAdapters {
 
     @BindingAdapter({"bind:imageUrl"})
     public static void loadImage(ImageView view, String url) {
-        RequestManager with = Glide.with(view.getContext());
-        DrawableTypeRequest<?> load;
+        Picasso with = Picasso.with(view.getContext());
+        RequestCreator load;
         if (url != null) {
             load = with.load(url);
         } else {
             load = with.load(thumbIds[position.getAndIncrement() % thumbIds.length]);
         }
-        //        int size = view.getWidth();
-        //        if (size > 0) {
-        //            load.override(size, size);
-        //        }
-        load.centerCrop().into(view);
+        load.into(view);
     }
 }


### PR DESCRIPTION
The picasso library has a small method footprint when compared to glide.  There's not really a great reason to switch, but when I brought in the google ad library, it pushed us over the 64k limit.  I'm guessing it's the backend that's doing it, since it brings in guava, but this will be a good change too.