### PR TITLE
Replace cocktail images with dummy images for better load time

### DIFF
--- a/app/src/main/java/com/bnorm/barkeep/BarkeepApp.java
+++ b/app/src/main/java/com/bnorm/barkeep/BarkeepApp.java
@@ -1,6 +1,7 @@
 package com.bnorm.barkeep;
 
 import android.app.Application;
+import com.squareup.picasso.Picasso;
 
 public class BarkeepApp extends Application {
 
@@ -10,6 +11,10 @@ public class BarkeepApp extends Application {
     public void onCreate() {
         super.onCreate();
         component = AppInjector.inject(getApplicationContext());
+
+        Picasso.Builder builder = new Picasso.Builder(getApplicationContext());
+        builder.indicatorsEnabled(true);
+        Picasso.setSingletonInstance(builder.build());
     }
 
     public AppComponent component() {

--- a/app/src/main/java/com/bnorm/barkeep/ui/book/BookDetailFragment.java
+++ b/app/src/main/java/com/bnorm/barkeep/ui/book/BookDetailFragment.java
@@ -107,7 +107,8 @@ public class BookDetailFragment extends BaseFragment {
 
             public void bind(Recipe recipe) {
                 recipeTitle.setText(recipe.getName());
-                BindingAdapters.loadImage(recipeImage, recipe.getPicture());
+                BindingAdapters.loadImage(recipeImage,
+                                          "http://dummyimage.com/400x400/000/fff.png&text=" + recipe.getName().replace(' ', '+'));
             }
         }
     }

--- a/app/src/main/java/com/bnorm/barkeep/ui/recipe/ViewRecipeActivity.java
+++ b/app/src/main/java/com/bnorm/barkeep/ui/recipe/ViewRecipeActivity.java
@@ -81,7 +81,7 @@ public class ViewRecipeActivity extends BaseActivity {
 
 
         // ===== Load recipe information ===== //
-        BindingAdapters.loadImage(recipeImage, recipe.getPicture());
+        BindingAdapters.loadImage(recipeImage, "http://dummyimage.com/400x400/000/fff.png&text=" + recipe.getName().replace(' ', '+'));
 
         for (Component component : recipe.getComponents()) {
             StringBuilder builder = new StringBuilder();


### PR DESCRIPTION
The cocktail grid always loaded really slowly because the images were not optimized for the display size.  These images still aren't optimized to the exact size but at least they are better.